### PR TITLE
add RouteHandler interface

### DIFF
--- a/handlers/helloWorld.go
+++ b/handlers/helloWorld.go
@@ -7,7 +7,18 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 )
 
-func helloWorld(request events.APIGatewayProxyRequest) (interface{}, int) {
+type helloWorld struct{}
+
+// NewRouter return the default implementation of the hello world route handler
+func newHelloWorld() RouteHandler {
+	return &helloWorld{}
+}
+
+func (h *helloWorld) match(request events.APIGatewayProxyRequest) bool {
+	return request.Path == "/hello"
+}
+
+func (h *helloWorld) handle(request events.APIGatewayProxyRequest) (interface{}, int) {
 	name := request.QueryStringParameters["name"]
 	return map[string]string{"message": fmt.Sprintf("Hello, %v", name)}, http.StatusOK
 }

--- a/handlers/helloWorld.go
+++ b/handlers/helloWorld.go
@@ -9,7 +9,6 @@ import (
 
 type helloWorld struct{}
 
-// NewRouter return the default implementation of the hello world route handler
 func newHelloWorld() RouteHandler {
 	return &helloWorld{}
 }

--- a/handlers/router.go
+++ b/handlers/router.go
@@ -11,6 +11,12 @@ type Router interface {
 	Route(events.APIGatewayProxyRequest) (interface{}, int)
 }
 
+// RouteHandler - interface for matching and handling a particular request
+type RouteHandler interface {
+	match(request events.APIGatewayProxyRequest) bool
+	handle(events.APIGatewayProxyRequest) (interface{}, int)
+}
+
 type router struct{}
 
 // NewRouter return the default implementation of Router
@@ -20,8 +26,15 @@ func NewRouter() Router {
 
 // Route call the appropriate handler for a request based on its path
 func (r *router) Route(request events.APIGatewayProxyRequest) (interface{}, int) {
-	if request.Path == "/hello" {
-		return helloWorld(request)
+	routes := []RouteHandler{
+		newHelloWorld(),
 	}
+
+	for _, route := range routes {
+		if route.match(request) {
+			return route.handle(request)
+		}
+	}
+
 	return nil, http.StatusNotFound
 }

--- a/handlers/router.go
+++ b/handlers/router.go
@@ -17,20 +17,21 @@ type RouteHandler interface {
 	handle(events.APIGatewayProxyRequest) (interface{}, int)
 }
 
-type router struct{}
+type router struct {
+	routes []RouteHandler
+}
 
 // NewRouter return the default implementation of Router
 func NewRouter() Router {
-	return &router{}
+	routes := []RouteHandler{
+		newHelloWorld(),
+	}
+	return &router{routes: routes}
 }
 
 // Route call the appropriate handler for a request based on its path
 func (r *router) Route(request events.APIGatewayProxyRequest) (interface{}, int) {
-	routes := []RouteHandler{
-		newHelloWorld(),
-	}
-
-	for _, route := range routes {
+	for _, route := range r.routes {
 		if route.match(request) {
 			return route.handle(request)
 		}

--- a/handlers/router_test.go
+++ b/handlers/router_test.go
@@ -1,0 +1,100 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockRoute struct {
+	mock.Mock
+}
+
+func (m *mockRoute) match(request events.APIGatewayProxyRequest) bool {
+	args := m.Called(request)
+	return args.Bool(0)
+}
+
+func (m *mockRoute) handle(request events.APIGatewayProxyRequest) (interface{}, int) {
+	args := m.Called(request)
+	return args.Get(0), args.Int(1)
+}
+
+func TestRoute(t *testing.T) {
+	bodyA := map[string]string{"route": "A"}
+	bodyB := map[string]string{"route": "B"}
+
+	tests := []struct {
+		name           string
+		matchResA      bool
+		matchResB      bool
+		expectedBody   interface{}
+		expectedStatus int
+	}{
+		{
+			name:           "No routes match then returns 404",
+			matchResA:      false,
+			matchResB:      false,
+			expectedBody:   nil,
+			expectedStatus: 404,
+		},
+		{
+			name:           "Route A matches then returns body A",
+			matchResA:      true,
+			matchResB:      false,
+			expectedBody:   bodyA,
+			expectedStatus: 200,
+		},
+		{
+			name:           "Route B matches then returns body B",
+			matchResA:      false,
+			matchResB:      true,
+			expectedBody:   bodyB,
+			expectedStatus: 200,
+		},
+		{
+			name:           "Both routes matches then returns body A",
+			matchResA:      true,
+			matchResB:      true,
+			expectedBody:   bodyA,
+			expectedStatus: 200,
+		},
+	}
+
+	request := events.APIGatewayProxyRequest{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			routeA := &mockRoute{}
+			routeA.Test(t)
+			routeA.
+				On("match", request).
+				Return(tt.matchResA)
+
+			routeA.
+				On("handle", request).
+				Return(bodyA, 200)
+
+			routeB := &mockRoute{}
+			routeB.Test(t)
+			routeB.
+				On("match", request).
+				Return(tt.matchResB)
+
+			routeB.
+				On("handle", request).
+				Return(bodyB, 200)
+
+			r := router{
+				routes: []RouteHandler{routeA, routeB},
+			}
+
+			gotRes, gotStatusCode := r.Route(request)
+
+			assert.Equal(t, tt.expectedBody, gotRes)
+			assert.Equal(t, tt.expectedStatus, gotStatusCode)
+		})
+	}
+}


### PR DESCRIPTION
Adds a new interface that has two methods:

```golang
type RouteHandler interface {
	match(request events.APIGatewayProxyRequest) bool
	handle(events.APIGatewayProxyRequest) (interface{}, int)
}
```

`match()` returns true if this particular handler should handle this request (based on path, headers, query string parameters etc.). `handle()` then handles the request and returns the response. 