### PR TITLE
Change configuration based on environement 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,9 @@
 package config
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 type conf struct {
 	getEnv func(string) string
@@ -13,20 +16,21 @@ func newConfig() *conf {
 }
 
 func (c *conf) getConf() Config {
-	switch c.getRuntimeEnvironment() {
+	switch env := c.getRuntimeEnvironment(); env {
 	case envNameProd:
 		return c.getProdConfig()
-	default:
+	case envNameDev:
 		return c.getDevConfig()
+	default:
+		panic(fmt.Sprintf("Unknown runtime enviroment: %s", env))
 	}
 }
 
-var environments map[string]bool = map[string]bool{envNameDev: true, envNameProd: true}
-
 func (c *conf) getRuntimeEnvironment() string {
-	value := c.getEnv(envVarEnvironment)
-	if environments[value] {
-		return value
+	environments := map[string]bool{envNameDev: true, envNameProd: true}
+	environment := c.getEnv(envVarEnvironment)
+	if _, ok := environments[environment]; ok {
+		return environment
 	}
 
 	return envNameDev

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,40 @@
+package config
+
+import "os"
+
+type conf struct {
+	getEnv func(string) string
+}
+
+func newConfig() *conf {
+	return &conf{
+		getEnv: func(key string) string { return os.Getenv(key) },
+	}
+}
+
+func (c *conf) getConf() Config {
+	switch c.getRuntimeEnvironment() {
+	case envNameProd:
+		return c.getProdConfig()
+	default:
+		return c.getDevConfig()
+	}
+}
+
+var environments map[string]bool = map[string]bool{envNameDev: true, envNameProd: true}
+
+func (c *conf) getRuntimeEnvironment() string {
+	value := c.getEnv(envVarEnvironment)
+	if environments[value] {
+		return value
+	}
+
+	return envNameDev
+}
+
+var loadedConfig Config = newConfig().getConf()
+
+// GetConfiguration returns the cofiguration values required at runtime
+func GetConfiguration() Config {
+	return loadedConfig
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetConfiguration(t *testing.T) {
+func TestGetConf(t *testing.T) {
 	tests := []struct {
 		name        string
 		runtimeEnv  string
@@ -50,15 +50,13 @@ func TestGetConfiguration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			getEnv := func(key string) string {
-				if key == "ENV" {
-					return tt.runtimeEnv
-				}
-				return fmt.Sprintf("env_%s", key)
-			}
-
 			confMocked := &conf{
-				getEnv: getEnv,
+				getEnv: func(key string) string {
+					if key == "ENV" {
+						return tt.runtimeEnv
+					}
+					return fmt.Sprintf("env_%s", key)
+				},
 			}
 
 			gotRes := confMocked.getConf()
@@ -66,4 +64,12 @@ func TestGetConfiguration(t *testing.T) {
 			assert.Equal(t, tt.expectedRes, gotRes)
 		})
 	}
+}
+
+func TestGetConfiguration(t *testing.T) {
+	conf := GetConfiguration()
+
+	assert.Greater(t, len(conf.Endpoint), 0)
+	assert.Greater(t, len(conf.TableNames.Items), 0)
+	assert.Greater(t, len(conf.TableNames.Lists), 0)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetConfiguration(t *testing.T) {
+	tests := []struct {
+		name        string
+		runtimeEnv  string
+		expectedRes Config
+	}{
+		{
+			name:       "When environment is dev then hardcoded values are used",
+			runtimeEnv: "DEV",
+			expectedRes: Config{
+				Endpoint: "http://localhost:8000",
+				TableNames: TableNames{
+					Items: "items",
+					Lists: "lists",
+				},
+			},
+		},
+		{
+			name:       "When environment is prod then environment variables are used",
+			runtimeEnv: "PROD",
+			expectedRes: Config{
+				Endpoint: "",
+				TableNames: TableNames{
+					Items: "env_TABLE_NAME_ITEMS",
+					Lists: "env_TABLE_NAME_LISTS",
+				},
+			},
+		},
+		{
+			name:       "When environment is nonsense then fallsback to dev values",
+			runtimeEnv: "nonsense",
+			expectedRes: Config{
+				Endpoint: "http://localhost:8000",
+				TableNames: TableNames{
+					Items: "items",
+					Lists: "lists",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getEnv := func(key string) string {
+				if key == "ENV" {
+					return tt.runtimeEnv
+				}
+				return fmt.Sprintf("env_%s", key)
+			}
+
+			confMocked := &conf{
+				getEnv: getEnv,
+			}
+
+			gotRes := confMocked.getConf()
+
+			assert.Equal(t, tt.expectedRes, gotRes)
+		})
+	}
+}

--- a/config/constants.go
+++ b/config/constants.go
@@ -1,0 +1,8 @@
+package config
+
+const envVarEnvironment string = "ENV"
+const envVarTableNameLists string = "TABLE_NAME_LISTS"
+const envVarTableNameItems string = "TABLE_NAME_ITEMS"
+
+const envNameDev string = "DEV"
+const envNameProd string = "PROD"

--- a/config/data.go
+++ b/config/data.go
@@ -1,0 +1,13 @@
+package config
+
+// TableNames contains the dynamodb table names
+type TableNames struct {
+	Items string
+	Lists string
+}
+
+// Config contains the cofiguration values required at runtime
+type Config struct {
+	Endpoint   string
+	TableNames TableNames
+}

--- a/config/devConfig.go
+++ b/config/devConfig.go
@@ -1,0 +1,8 @@
+package config
+
+func (c *conf) getDevConfig() Config {
+	return Config{
+		Endpoint:   "http://localhost:8000",
+		TableNames: TableNames{Items: "items", Lists: "lists"},
+	}
+}

--- a/config/prodConfig.go
+++ b/config/prodConfig.go
@@ -1,0 +1,11 @@
+package config
+
+func (c *conf) getProdConfig() Config {
+	return Config{
+		Endpoint: "",
+		TableNames: TableNames{
+			Items: c.getEnv(envVarTableNameItems),
+			Lists: c.getEnv(envVarTableNameLists),
+		},
+	}
+}

--- a/db/constants.go
+++ b/db/constants.go
@@ -1,5 +1,0 @@
-package db
-
-const dbEndpoint string = "http://localhost:8000/"
-const dbTableNameItems string = "items"
-const dbTableNameLists string = "lists"

--- a/db/dynamodb.go
+++ b/db/dynamodb.go
@@ -5,15 +5,18 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
+	"github.com/mount-joy/thelist-lambda/config"
 )
 
 type dynamoDB struct {
 	session dynamodbiface.DynamoDBAPI
+	conf    config.Config
 }
 
 func createInstance() DB {
-	config := aws.Config{Endpoint: aws.String(dbEndpoint)}
-	return &dynamoDB{session: dynamodb.New(session.New(&config))}
+	conf := config.GetConfiguration()
+	config := aws.Config{Endpoint: aws.String(conf.Endpoint)}
+	return &dynamoDB{session: dynamodb.New(session.New(&config)), conf: conf}
 }
 
 var instance DB = createInstance()

--- a/db/getItemsOnList.go
+++ b/db/getItemsOnList.go
@@ -15,7 +15,7 @@ func (d *dynamoDB) GetItemsOnList(listID *string) (*[]data.Item, error) {
 			":id": {S: listID},
 		},
 		KeyConditionExpression: aws.String("ListId = :id"),
-		TableName:              aws.String(dbTableNameItems),
+		TableName:              aws.String(d.conf.TableNames.Items),
 	}
 
 	result, err := d.session.Query(input)

--- a/db/getItemsOnList_test.go
+++ b/db/getItemsOnList_test.go
@@ -23,15 +23,14 @@ func (m *mockDB) Query(input *dynamodb.QueryInput) (*dynamodb.QueryOutput, error
 	return args.Get(0).(*dynamodb.QueryOutput), args.Error(1)
 }
 
-var testConfig config.Config = config.Config{
-	Endpoint: "db://thelist",
-	TableNames: config.TableNames{
-		Items: "items-table",
-		Lists: "lists-table",
-	},
-}
-
 func TestGetItemsOnList(t *testing.T) {
+	testConfig := config.Config{
+		Endpoint: "db://thelist",
+		TableNames: config.TableNames{
+			Items: "items-table",
+			Lists: "lists-table",
+		},
+	}
 	tests := []struct {
 		name        string
 		output      *dynamodb.QueryOutput


### PR DESCRIPTION
This PR allows different configuration to be loaded for different environments. This is required as things like the database endpoint url and table names will change between local running and running in production.

For now local values are hardcoded and production values are fed from environment variables, this can be changed as required.