### PR TITLE
Upgrade to api gateway v2

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .aws-sam
 lambda.zip
 main
+venv

--- a/handlers/getItems.go
+++ b/handlers/getItems.go
@@ -22,13 +22,13 @@ func newGetItems() RouteHandler {
 	}
 }
 
-func (g *getItems) match(request events.APIGatewayProxyRequest) bool {
+func (g *getItems) match(request events.APIGatewayV2HTTPRequest) bool {
 	var re = regexp.MustCompile(`^/lists/([\w-]+)/items/?$`)
-	return re.MatchString(request.Path)
+	return re.MatchString(request.RequestContext.HTTP.Path)
 }
 
-func (g *getItems) handle(request events.APIGatewayProxyRequest) (interface{}, int) {
-	items, err := g.getItems(request.Path)
+func (g *getItems) handle(request events.APIGatewayV2HTTPRequest) (interface{}, int) {
+	items, err := g.getItems(request.RequestContext.HTTP.Path)
 
 	if err != nil {
 		log.Printf("Error: %s", err.Error())

--- a/handlers/getItems_test.go
+++ b/handlers/getItems_test.go
@@ -78,7 +78,13 @@ func TestGetItemsMatch(t *testing.T) {
 			dbMocked.Test(t)
 			defer dbMocked.AssertExpectations(t)
 
-			input := events.APIGatewayProxyRequest{Path: tt.path}
+			input := events.APIGatewayV2HTTPRequest{
+				RequestContext: events.APIGatewayV2HTTPRequestContext{
+					HTTP: events.APIGatewayV2HTTPRequestContextHTTPDescription{
+						Path: tt.path,
+					},
+				},
+			}
 			d := getItems{db: dbMocked}
 			gotRes := d.match(input)
 
@@ -154,8 +160,12 @@ func TestGetItemsHandle(t *testing.T) {
 
 			d := getItems{db: dbMocked}
 
-			input := events.APIGatewayProxyRequest{
-				Path: tt.path,
+			input := events.APIGatewayV2HTTPRequest{
+				RequestContext: events.APIGatewayV2HTTPRequestContext{
+					HTTP: events.APIGatewayV2HTTPRequestContextHTTPDescription{
+						Path: tt.path,
+					},
+				},
 			}
 			gotRes, statusCode := d.handle(input)
 

--- a/handlers/helloWorld.go
+++ b/handlers/helloWorld.go
@@ -13,11 +13,11 @@ func newHelloWorld() RouteHandler {
 	return &helloWorld{}
 }
 
-func (h *helloWorld) match(request events.APIGatewayProxyRequest) bool {
-	return request.Path == "/hello"
+func (h *helloWorld) match(request events.APIGatewayV2HTTPRequest) bool {
+	return request.RequestContext.HTTP.Path == "/hello"
 }
 
-func (h *helloWorld) handle(request events.APIGatewayProxyRequest) (interface{}, int) {
+func (h *helloWorld) handle(request events.APIGatewayV2HTTPRequest) (interface{}, int) {
 	name := request.QueryStringParameters["name"]
 	return map[string]string{"message": fmt.Sprintf("Hello, %v", name)}, http.StatusOK
 }

--- a/handlers/router.go
+++ b/handlers/router.go
@@ -8,13 +8,13 @@ import (
 
 // Router - interface for routing requests to the right handler
 type Router interface {
-	Route(events.APIGatewayProxyRequest) (interface{}, int)
+	Route(events.APIGatewayV2HTTPRequest) (interface{}, int)
 }
 
 // RouteHandler - interface for matching and handling a particular request
 type RouteHandler interface {
-	match(request events.APIGatewayProxyRequest) bool
-	handle(events.APIGatewayProxyRequest) (interface{}, int)
+	match(events.APIGatewayV2HTTPRequest) bool
+	handle(events.APIGatewayV2HTTPRequest) (interface{}, int)
 }
 
 type router struct {
@@ -31,7 +31,7 @@ func NewRouter() Router {
 }
 
 // Route call the appropriate handler for a request based on its path
-func (r *router) Route(request events.APIGatewayProxyRequest) (interface{}, int) {
+func (r *router) Route(request events.APIGatewayV2HTTPRequest) (interface{}, int) {
 	for _, route := range r.routes {
 		if route.match(request) {
 			return route.handle(request)

--- a/handlers/router_test.go
+++ b/handlers/router_test.go
@@ -12,12 +12,12 @@ type mockRoute struct {
 	mock.Mock
 }
 
-func (m *mockRoute) match(request events.APIGatewayProxyRequest) bool {
+func (m *mockRoute) match(request events.APIGatewayV2HTTPRequest) bool {
 	args := m.Called(request)
 	return args.Bool(0)
 }
 
-func (m *mockRoute) handle(request events.APIGatewayProxyRequest) (interface{}, int) {
+func (m *mockRoute) handle(request events.APIGatewayV2HTTPRequest) (interface{}, int) {
 	args := m.Called(request)
 	return args.Get(0), args.Int(1)
 }
@@ -63,7 +63,7 @@ func TestRoute(t *testing.T) {
 		},
 	}
 
-	request := events.APIGatewayProxyRequest{}
+	request := events.APIGatewayV2HTTPRequest{}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ type handler struct {
 	router handlers.Router
 }
 
-func (h *handler) doRequest(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+func (h *handler) doRequest(request events.APIGatewayV2HTTPRequest) (events.APIGatewayProxyResponse, error) {
 	result, statusCode := h.router.Route(request)
 
 	res, err := json.Marshal(result)

--- a/main.go
+++ b/main.go
@@ -13,18 +13,18 @@ type handler struct {
 	router handlers.Router
 }
 
-func (h *handler) doRequest(request events.APIGatewayV2HTTPRequest) (events.APIGatewayProxyResponse, error) {
+func (h *handler) doRequest(request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
 	result, statusCode := h.router.Route(request)
 
 	res, err := json.Marshal(result)
 	if err != nil {
-		return events.APIGatewayProxyResponse{
+		return events.APIGatewayV2HTTPResponse{
 			Body:       err.Error(),
 			StatusCode: 500,
 		}, nil
 	}
 
-	return events.APIGatewayProxyResponse{
+	return events.APIGatewayV2HTTPResponse{
 		Body:       string(res),
 		StatusCode: statusCode,
 	}, nil

--- a/main_test.go
+++ b/main_test.go
@@ -24,8 +24,12 @@ func TestFullFlow(t *testing.T) {
 			router: handlers.NewRouter(),
 		}
 
-		request := events.APIGatewayProxyRequest{
-			Path:                  "/hello",
+		request := events.APIGatewayV2HTTPRequest{
+			RequestContext: events.APIGatewayV2HTTPRequestContext{
+				HTTP: events.APIGatewayV2HTTPRequestContextHTTPDescription{
+					Path: "/hello",
+				},
+			},
 			QueryStringParameters: map[string]string{"name": "Joy"},
 		}
 
@@ -41,7 +45,7 @@ type mockRouter struct {
 	mock.Mock
 }
 
-func (mr *mockRouter) Route(request events.APIGatewayProxyRequest) (interface{}, int) {
+func (mr *mockRouter) Route(request events.APIGatewayV2HTTPRequest) (interface{}, int) {
 	args := mr.Called(request)
 	return args.Get(0), args.Int(1)
 }
@@ -53,7 +57,7 @@ func TestHandler(t *testing.T) {
 	}
 	tests := []struct {
 		name           string
-		request        events.APIGatewayProxyRequest
+		request        events.APIGatewayV2HTTPRequest
 		mockRoute      mockRoute
 		expectedBody   string
 		expectedStatus int
@@ -61,8 +65,12 @@ func TestHandler(t *testing.T) {
 	}{
 		{
 			name: "Router doesn't error",
-			request: events.APIGatewayProxyRequest{
-				Path: "/test",
+			request: events.APIGatewayV2HTTPRequest{
+				RequestContext: events.APIGatewayV2HTTPRequestContext{
+					HTTP: events.APIGatewayV2HTTPRequestContextHTTPDescription{
+						Path: "/test",
+					},
+				},
 			},
 			mockRoute: mockRoute{
 				body:   map[string]string{"message": fmt.Sprintf("huge success")},
@@ -73,8 +81,12 @@ func TestHandler(t *testing.T) {
 		},
 		{
 			name: "Route returns nil",
-			request: events.APIGatewayProxyRequest{
-				Path: "/test",
+			request: events.APIGatewayV2HTTPRequest{
+				RequestContext: events.APIGatewayV2HTTPRequestContext{
+					HTTP: events.APIGatewayV2HTTPRequestContextHTTPDescription{
+						Path: "/test",
+					},
+				},
 			},
 			mockRoute: mockRoute{
 				body:   nil,

--- a/template.yaml
+++ b/template.yaml
@@ -5,39 +5,26 @@ Description: >
 
   Sample SAM Template for thelist-lambda
 
-# More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
-Globals:
-  Function:
-    Timeout: 5
-
 Resources:
   HelloWorldFunction:
-    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Type: AWS::Serverless::Function
     Properties:
       CodeUri: ./
       Handler: main
       Runtime: go1.x
-      Tracing: Active # https://docs.aws.amazon.com/lambda/latest/dg/lambda-x-ray.html
       Events:
         CatchAll:
-          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+          Type: HttpApi
           Properties:
+            ApiId: !Ref HttpApi
             Path: /{proxy+}
+            TimeoutInMillis: 10000
+            PayloadFormatVersion: "2.0"
             Method: GET
-      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
-        Variables:
-          PARAM1: VALUE
 
-Outputs:
-  # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
-  # Find out more about other implicit resources you can reference within SAM
-  # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
-  HelloWorldAPI:
-    Description: "API Gateway endpoint URL for Prod environment for First Function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
-  HelloWorldFunction:
-    Description: "First Lambda Function ARN"
-    Value: !GetAtt HelloWorldFunction.Arn
-  HelloWorldFunctionIamRole:
-    Description: "Implicit IAM Role created for Hello World function"
-    Value: !GetAtt HelloWorldFunctionRole.Arn
+  HttpApi:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      DefaultRouteSettings:
+        ThrottlingBurstLimit: 200
+      FailOnWarnings: True


### PR DESCRIPTION
I hadn't realised until now that the api gateway we have running in AWS is v2, and the one we're running locally is v1. This PR updates us to use v2.

There's a comparison of the differences here:
https://www.serverless.com/blog/api-gateway-v2-http-apis