### PR TITLE
Run linting in CI

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,15 @@
+name: golangci-lint
+on:
+  push:
+  pull_request:
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.32

--- a/db/constants.go
+++ b/db/constants.go
@@ -2,4 +2,5 @@ package db
 
 const dbEndpoint string = "http://localhost:8000/"
 const dbTableNameItems string = "items"
-const dbTableNameLists string = "lists"
+
+// const dbTableNameLists string = "lists"

--- a/db/dynamodb.go
+++ b/db/dynamodb.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
@@ -13,7 +15,11 @@ type dynamoDB struct {
 
 func createInstance() DB {
 	config := aws.Config{Endpoint: aws.String(dbEndpoint)}
-	return &dynamoDB{session: dynamodb.New(session.New(&config))}
+	session, err := session.NewSession(&config)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to create dynamodb session: %s", err.Error()))
+	}
+	return &dynamoDB{session: dynamodb.New(session)}
 }
 
 var instance DB = createInstance()

--- a/main_test.go
+++ b/main_test.go
@@ -65,7 +65,7 @@ func TestHandler(t *testing.T) {
 				Path: "/test",
 			},
 			mockRoute: mockRoute{
-				body:   map[string]string{"message": fmt.Sprintf("huge success")},
+				body:   map[string]string{"message": "huge success"},
 				status: 200,
 			},
 			expectedBody:   "{\"message\":\"huge success\"}",


### PR DESCRIPTION
1. Adds a GitHub action to run linting in the CI: https://github.com/golangci/golangci-lint
1. Fixes any linting errors