### PR TITLE
Add GET /list/<list_id> request

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -11,5 +11,6 @@ type DB interface {
 	DeleteItem(string, string) error
 	GetItem(listID string, itemID string) (*data.Item, error)
 	GetItemsOnList(string) (*[]data.Item, error)
+	GetList(listID string) (*data.List, error)
 	UpdateItem(string, string, string, *bool) (*data.Item, error)
 }

--- a/db/getList.go
+++ b/db/getList.go
@@ -1,0 +1,35 @@
+package db
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	"github.com/mount-joy/thelist-lambda/data"
+)
+
+func (d *dynamoDB) GetList(listID string) (*data.List, error) {
+	tableName := d.conf.TableNames.Lists
+	if len(tableName) == 0 {
+		panic("Items table name not set")
+	}
+
+	key, err := dynamodbattribute.MarshalMap(data.ListKey{ID: listID})
+
+	if err != nil {
+		return nil, err
+	}
+
+	input := &dynamodb.GetItemInput{
+		Key:       key,
+		TableName: aws.String(tableName),
+	}
+	res, err := d.session.GetItem(input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	item := new(data.List)
+	err = dynamodbattribute.UnmarshalMap(res.Item, &item)
+	return item, err
+}

--- a/db/getList_test.go
+++ b/db/getList_test.go
@@ -1,0 +1,67 @@
+package db
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/mount-joy/thelist-lambda/data"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetList(t *testing.T) {
+	listID := "474c2Fff7"
+	name := "Cheese"
+	tests := []struct {
+		name          string
+		mockOutputErr error
+		mockOutput    *dynamodb.GetItemOutput
+		expectedRes   *data.List
+		expectedErr   error
+	}{
+		{
+			name:          "If the item exists it is retrieved",
+			mockOutputErr: nil,
+			mockOutput: &dynamodb.GetItemOutput{
+				Item: map[string]*dynamodb.AttributeValue{
+					"Id":   {S: &listID},
+					"Name": {S: &name},
+				},
+			},
+			expectedRes: &data.List{ListKey: data.ListKey{ID: listID}, Name: name},
+			expectedErr: nil,
+		},
+		{
+			name:          "When db returns an error, that error is returned",
+			mockOutputErr: errors.New("Something went wrong"),
+			mockOutput:    nil,
+			expectedRes:   nil,
+			expectedErr:   errors.New("Something went wrong"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dbMocked := &mockDB{}
+			dbMocked.Test(t)
+			defer dbMocked.AssertExpectations(t)
+
+			input := dynamodb.GetItemInput{
+				Key: map[string]*dynamodb.AttributeValue{
+					"Id": {S: &listID},
+				},
+				TableName: stringToPointer("lists-table"),
+			}
+			dbMocked.
+				On("GetItem", &input).
+				Return(tt.mockOutput, tt.mockOutputErr).
+				Once()
+
+			d := dynamoDB{session: dbMocked, conf: testConfig}
+			gotRes, gotErr := d.GetList(listID)
+
+			assert.Equal(t, tt.expectedErr, gotErr)
+			assert.Equal(t, tt.expectedRes, gotRes)
+		})
+	}
+}

--- a/handlers/getlist/getList.go
+++ b/handlers/getlist/getList.go
@@ -1,0 +1,61 @@
+package getlist
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/mount-joy/thelist-lambda/data"
+	"github.com/mount-joy/thelist-lambda/db"
+	"github.com/mount-joy/thelist-lambda/handlers/iface"
+)
+
+type getList struct {
+	db db.DB
+}
+
+// New returns an instance of deleteItem satisfying the RouteHandler interface
+func New() iface.RouteHandler {
+	return &getList{
+		db: db.DynamoDB(),
+	}
+}
+
+// Match returns true if this RouteHandler should handle this request
+func (g *getList) Match(request events.APIGatewayV2HTTPRequest) bool {
+	// GET /lists/<list_id>
+	var re = regexp.MustCompile(`^/lists/([\w-]+)/?$`)
+	return request.RequestContext.HTTP.Method == "GET" && re.MatchString(request.RequestContext.HTTP.Path)
+}
+
+// Handle handles this request and returns the response and status code
+func (g *getList) Handle(request events.APIGatewayV2HTTPRequest) (interface{}, int) {
+	item, err := g.getList(request.RequestContext.HTTP.Path)
+
+	if err != nil {
+		log.Printf("Error: %s", err.Error())
+		return nil, http.StatusInternalServerError
+	}
+
+	return item, http.StatusOK
+}
+
+func (g *getList) getList(path string) (*data.List, error) {
+	listID, err := getID(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return g.db.GetList(listID)
+}
+
+func getID(path string) (string, error) {
+	parts := strings.SplitN(path, "/", 4)
+	if len(parts) < 3 {
+		return "", fmt.Errorf("Unable to match path: %s", path)
+	}
+	return parts[2], nil
+}

--- a/handlers/getlist/getList_test.go
+++ b/handlers/getlist/getList_test.go
@@ -1,0 +1,177 @@
+package getlist
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mount-joy/thelist-lambda/handlers/testhelpers"
+
+	"github.com/mount-joy/thelist-lambda/data"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetListMatch(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		method      string
+		expectedRes bool
+	}{
+		{
+			name:        "Returns true for a matching path",
+			path:        "/lists/b6cf642d/",
+			method:      "GET",
+			expectedRes: true,
+		},
+		{
+			name:        "Returns true for a uppercase ID",
+			path:        "/lists/B6CF642D/",
+			method:      "GET",
+			expectedRes: true,
+		},
+		{
+			name:        "Returns true without trailing slash",
+			path:        "/lists/b6cf642d/",
+			method:      "GET",
+			expectedRes: true,
+		},
+		{
+			name:        "Returns false for item path",
+			path:        "/lists/b6cf642d/items/73bb82c4/",
+			method:      "GET",
+			expectedRes: false,
+		},
+		{
+			name:        "Returns false for list path without trailing slash",
+			path:        "/lists/b6cf642ditems/73bb82c4",
+			method:      "GET",
+			expectedRes: false,
+		},
+		{
+			name:        "Returns false for lists path",
+			path:        "/lists/",
+			method:      "GET",
+			expectedRes: false,
+		},
+		{
+			name:        "Returns false for lists path without trailing slash",
+			path:        "/lists",
+			method:      "GET",
+			expectedRes: false,
+		},
+		{
+			name:        "Returns false for items path",
+			path:        "/lists/b6cf642d-7a72-4969-bcc9-73bb82c4b3f6/items",
+			method:      "GET",
+			expectedRes: false,
+		},
+		{
+			name:        "Returns false when path is empty",
+			path:        "",
+			method:      "GET",
+			expectedRes: false,
+		},
+		{
+			name:        "Returns false for a POST request",
+			path:        "/lists/b6cf642d/items/73bb82c4/",
+			method:      "POST",
+			expectedRes: false,
+		},
+		{
+			name:        "Returns false for a DELETE request",
+			path:        "/lists/b6cf642d/items/73bb82c4/",
+			method:      "DELETE",
+			expectedRes: false,
+		},
+		{
+			name:        "Returns false for a PATCH request",
+			path:        "/lists/b6cf642d/items/73bb82c4/",
+			method:      "PATCH",
+			expectedRes: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dbMocked := &testhelpers.MockDB{}
+			dbMocked.Test(t)
+			defer dbMocked.AssertExpectations(t)
+
+			input := testhelpers.CreateAPIGatewayV2HTTPRequest(tt.path, tt.method, "")
+			d := getList{db: dbMocked}
+			gotRes := d.Match(input)
+
+			assert.Equal(t, tt.expectedRes, gotRes)
+		})
+	}
+}
+
+type mockGetList struct {
+	res *data.List
+	err error
+}
+
+func TestGetItemHandle(t *testing.T) {
+	tests := []struct {
+		name               string
+		path               string
+		listID             string
+		mockOutput         *mockGetList
+		expectedRes        interface{}
+		expectedStatusCode int
+	}{
+		{
+			name:               "Returns 'Internal Server Error' when the path is empty",
+			path:               "",
+			listID:             "test-list-id",
+			expectedRes:        nil,
+			expectedStatusCode: 500,
+		},
+		{
+			name:               "Returns 'Internal Server Error' when the path is not in the correct format",
+			path:               "/lists",
+			listID:             "test-list-id",
+			expectedRes:        nil,
+			expectedStatusCode: 500,
+		},
+		{
+			name:               "Returns 'OK' and results when the path matches",
+			path:               "/lists/test-list-id/",
+			listID:             "test-list-id",
+			mockOutput:         &mockGetList{res: &data.List{Name: "ABC", ListKey: data.ListKey{ID: "888"}}, err: nil},
+			expectedRes:        &data.List{Name: "ABC", ListKey: data.ListKey{ID: "888"}},
+			expectedStatusCode: 200,
+		},
+		{
+			name:               "Returns 'Internal Server Error' when db returns an error",
+			path:               "/lists/test-list-id/",
+			listID:             "test-list-id",
+			mockOutput:         &mockGetList{res: nil, err: errors.New("It went bad")},
+			expectedRes:        nil,
+			expectedStatusCode: 500,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dbMocked := &testhelpers.MockDB{}
+			dbMocked.Test(t)
+			defer dbMocked.AssertExpectations(t)
+
+			if tt.mockOutput != nil {
+				dbMocked.
+					On("GetList", tt.listID).
+					Return(tt.mockOutput.res, tt.mockOutput.err).
+					Once()
+			}
+
+			d := getList{db: dbMocked}
+
+			input := testhelpers.CreateAPIGatewayV2HTTPRequest(tt.path, "GET", "")
+			gotRes, statusCode := d.Handle(input)
+
+			assert.Equal(t, tt.expectedStatusCode, statusCode)
+			assert.Equal(t, tt.expectedRes, gotRes)
+		})
+	}
+}

--- a/handlers/router.go
+++ b/handlers/router.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mount-joy/thelist-lambda/handlers/deleteitem"
 	"github.com/mount-joy/thelist-lambda/handlers/getitem"
 	"github.com/mount-joy/thelist-lambda/handlers/getitems"
+	"github.com/mount-joy/thelist-lambda/handlers/getlist"
 	"github.com/mount-joy/thelist-lambda/handlers/helloworld"
 	"github.com/mount-joy/thelist-lambda/handlers/iface"
 	"github.com/mount-joy/thelist-lambda/handlers/patchitem"
@@ -25,6 +26,7 @@ func NewRouter() iface.Router {
 		deleteitem.New(),
 		getitem.New(),
 		getitems.New(),
+		getlist.New(),
 		postitem.New(),
 		postlist.New(),
 		helloworld.New(),

--- a/handlers/testhelpers/db.go
+++ b/handlers/testhelpers/db.go
@@ -28,6 +28,12 @@ func (m *MockDB) GetItem(listID string, itemID string) (*data.Item, error) {
 	return args.Get(0).(*data.Item), args.Error(1)
 }
 
+// GetList mocks the DB GetItem method
+func (m *MockDB) GetList(listID string) (*data.List, error) {
+	args := m.Called(listID)
+	return args.Get(0).(*data.List), args.Error(1)
+}
+
 // DeleteItem mocks the DB DeleteItem method
 func (m *MockDB) DeleteItem(listID string, itemID string) error {
 	args := m.Called(listID, itemID)


### PR DESCRIPTION
This endpoint is needed when we share a list in order to get its list name