### PR TITLE
Add created and updated timestamps for lists and items

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -13,7 +13,9 @@ type ListKey struct {
 // List represents the data structure of a list
 type List struct {
 	ListKey
-	Name string `json:"Name"`
+	Name             string `json:"Name"`
+	CreatedTimestamp string `json:"Created"`
+	UpdatedTimestamp string `json:"Updated"`
 }
 
 // ItemKey represents the primary key of an item
@@ -25,8 +27,10 @@ type ItemKey struct {
 // Item represents the data structure of an item on a list
 type Item struct {
 	ItemKey
-	Name        string `json:"Name"`
-	IsCompleted bool   `json:"IsCompleted"`
+	Name             string `json:"Name"`
+	IsCompleted      bool   `json:"IsCompleted"`
+	CreatedTimestamp string `json:"Created"`
+	UpdatedTimestamp string `json:"Updated"`
 }
 
 // GetNameFieldInJson gets the value of "Name" from the passed in json

--- a/db/createItem.go
+++ b/db/createItem.go
@@ -10,14 +10,17 @@ import (
 
 func (d *dynamoDB) CreateItem(listID string, name string) (*data.Item, error) {
 	itemID := d.generateID()
+	timestamp := d.getTimestamp()
 
 	item := &data.Item{
 		ItemKey: data.ItemKey{
 			ListID: listID,
 			ID:     itemID,
 		},
-		Name:        name,
-		IsCompleted: false,
+		Name:             name,
+		IsCompleted:      false,
+		CreatedTimestamp: timestamp,
+		UpdatedTimestamp: timestamp,
 	}
 	itemToInsert, err := dynamodbattribute.MarshalMap(item)
 	if err != nil {

--- a/db/createItem_test.go
+++ b/db/createItem_test.go
@@ -14,6 +14,8 @@ func TestCreateItem(t *testing.T) {
 	listID := "474c2Fff7"
 	itemID := "b6cf642d"
 	itemName := "Peaches"
+	timestamp := "2020-01-23T09:59:14.9396531Z"
+
 	tests := []struct {
 		name           string
 		item           map[string]*dynamodb.AttributeValue
@@ -23,26 +25,26 @@ func TestCreateItem(t *testing.T) {
 	}{
 		{
 			name:           "If the ID does not exists it creates the item",
-			item:           map[string]*dynamodb.AttributeValue{"Id": {S: &itemID}, "ListId": {S: &listID}, "Name": {S: &itemName}, "IsCompleted": {BOOL: boolToPointer(false)}},
+			item:           createExpectedInput(itemID, listID, itemName, false, timestamp),
 			mockOutputErr:  nil,
-			expectedOutput: &data.Item{ItemKey: data.ItemKey{ID: itemID, ListID: listID}, Name: itemName, IsCompleted: false},
+			expectedOutput: &data.Item{ItemKey: data.ItemKey{ID: itemID, ListID: listID}, Name: itemName, IsCompleted: false, UpdatedTimestamp: timestamp, CreatedTimestamp: timestamp},
 			expectedErr:    nil,
 		},
 		{
 			name:          "When db returns an error, that error is returned",
-			item:          map[string]*dynamodb.AttributeValue{"Id": {S: &itemID}, "ListId": {S: &listID}, "Name": {S: &itemName}, "IsCompleted": {BOOL: boolToPointer(false)}},
+			item:          createExpectedInput(itemID, listID, itemName, false, timestamp),
 			mockOutputErr: errors.New("Something went wrong"),
 			expectedErr:   errors.New("Something went wrong"),
 		},
 		{
 			name:          "When DB returns condition not match error, not found error is returned",
-			item:          map[string]*dynamodb.AttributeValue{"Id": {S: &itemID}, "ListId": {S: &listID}, "Name": {S: &itemName}, "IsCompleted": {BOOL: boolToPointer(false)}},
+			item:          createExpectedInput(itemID, listID, itemName, false, timestamp),
 			mockOutputErr: awserr.New(dynamodb.ErrCodeConditionalCheckFailedException, "Bad", errors.New("Oh dear")),
 			expectedErr:   ErrorIDExists,
 		},
 		{
 			name:          "When DB unrecognised awserr, passon the error",
-			item:          map[string]*dynamodb.AttributeValue{"Id": {S: &itemID}, "ListId": {S: &listID}, "Name": {S: &itemName}, "IsCompleted": {BOOL: boolToPointer(false)}},
+			item:          createExpectedInput(itemID, listID, itemName, false, timestamp),
 			mockOutputErr: awserr.New("uh oh", "whoops", errors.New("Oh dear")),
 			expectedErr:   awserr.New("uh oh", "whoops", errors.New("Oh dear")),
 		},
@@ -64,11 +66,27 @@ func TestCreateItem(t *testing.T) {
 				Return(&dynamodb.PutItemOutput{}, tt.mockOutputErr).
 				Once()
 
-			d := dynamoDB{session: dbMocked, conf: testConfig, generateID: func() string { return itemID }}
+			d := dynamoDB{
+				session:      dbMocked,
+				conf:         testConfig,
+				generateID:   func() string { return itemID },
+				getTimestamp: func() string { return timestamp },
+			}
 			gotRes, gotErr := d.CreateItem(listID, itemName)
 
 			assert.Equal(t, tt.expectedOutput, gotRes)
 			assert.Equal(t, tt.expectedErr, gotErr)
 		})
+	}
+}
+
+func createExpectedInput(itemID string, listID string, itemName string, isCompleted bool, timestamp string) map[string]*dynamodb.AttributeValue {
+	return map[string]*dynamodb.AttributeValue{
+		"Id":          {S: &itemID},
+		"ListId":      {S: &listID},
+		"Name":        {S: &itemName},
+		"IsCompleted": {BOOL: &isCompleted},
+		"Created":     {S: &timestamp},
+		"Updated":     {S: &timestamp},
 	}
 }

--- a/db/createList.go
+++ b/db/createList.go
@@ -9,11 +9,15 @@ import (
 )
 
 func (d *dynamoDB) CreateList(listName string) (*data.List, error) {
+	timestamp := d.getTimestamp()
+
 	list := &data.List{
 		ListKey: data.ListKey{
 			ID: d.generateID(),
 		},
-		Name: listName,
+		Name:             listName,
+		CreatedTimestamp: timestamp,
+		UpdatedTimestamp: timestamp,
 	}
 
 	listToInsert, err := dynamodbattribute.MarshalMap(list)

--- a/db/createList_test.go
+++ b/db/createList_test.go
@@ -13,6 +13,8 @@ import (
 
 func TestCreateList(t *testing.T) {
 	listID := "1234"
+	timestamp := "2020-01-23T09:59:14.9396531Z"
+
 	tests := []struct {
 		name           string
 		listName       string
@@ -24,7 +26,7 @@ func TestCreateList(t *testing.T) {
 			name:           "If dynamodb passes, creates the list",
 			listName:       "my-list",
 			mockOutputErr:  nil,
-			expectedOutput: &data.List{ListKey: data.ListKey{ID: listID}, Name: "my-list"},
+			expectedOutput: &data.List{ListKey: data.ListKey{ID: listID}, Name: "my-list", CreatedTimestamp: timestamp, UpdatedTimestamp: timestamp},
 			expectedErr:    nil,
 		},
 		{
@@ -50,8 +52,10 @@ func TestCreateList(t *testing.T) {
 			defer dbMocked.AssertExpectations(t)
 
 			item := map[string]*dynamodb.AttributeValue{
-				"Id":   {S: &listID},
-				"Name": {S: &tt.listName},
+				"Id":      {S: &listID},
+				"Name":    {S: &tt.listName},
+				"Created": {S: &timestamp},
+				"Updated": {S: &timestamp},
 			}
 			input := dynamodb.PutItemInput{
 				Item:                item,
@@ -64,9 +68,10 @@ func TestCreateList(t *testing.T) {
 				Once()
 
 			d := dynamoDB{
-				session:    dbMocked,
-				conf:       testConfig,
-				generateID: func() string { return listID },
+				session:      dbMocked,
+				conf:         testConfig,
+				generateID:   func() string { return listID },
+				getTimestamp: func() string { return timestamp },
 			}
 
 			gotRes, gotErr := d.CreateList(tt.listName)

--- a/db/dynamodb.go
+++ b/db/dynamodb.go
@@ -11,9 +11,10 @@ import (
 )
 
 type dynamoDB struct {
-	session    dynamodbiface.DynamoDBAPI
-	conf       config.Config
-	generateID func() string
+	session      dynamodbiface.DynamoDBAPI
+	conf         config.Config
+	generateID   func() string
+	getTimestamp func() string
 }
 
 func createInstance() DB {
@@ -24,9 +25,10 @@ func createInstance() DB {
 		panic(fmt.Sprintf("Failed to create dynamodb session: %s", err.Error()))
 	}
 	return &dynamoDB{
-		session:    dynamodb.New(session),
-		conf:       conf,
-		generateID: func() string { return generateID() },
+		session:      dynamodb.New(session),
+		conf:         conf,
+		generateID:   func() string { return generateID() },
+		getTimestamp: func() string { return getTimestamp() },
 	}
 }
 

--- a/db/helpers.go
+++ b/db/helpers.go
@@ -1,9 +1,15 @@
 package db
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 )
 
 func generateID() string {
 	return uuid.New().String()
+}
+
+func getTimestamp() string {
+	return time.Now().UTC().Format(time.RFC3339Nano)
 }

--- a/db/helpers_test.go
+++ b/db/helpers_test.go
@@ -3,13 +3,14 @@ package db
 import (
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-var re = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
-
 func TestGenerateID(t *testing.T) {
+	re := regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
 	t.Run("should return a UUIDv4", func(t *testing.T) {
 		for i := 1; i <= 1000; i++ {
 			id := generateID()
@@ -30,5 +31,30 @@ func TestGenerateID(t *testing.T) {
 		}
 
 		assert.Equal(t, n, len(setOfIDs))
+	})
+}
+
+func TestGetTimestamp(t *testing.T) {
+	n := 100
+	setOfTimestamps := make(map[string]bool, n)
+
+	for i := 1; i <= n; i++ {
+		id := getTimestamp()
+		setOfTimestamps[id] = true
+		time.Sleep(1 * time.Microsecond) // ensure some time has passed between each one
+	}
+
+	t.Run("Timestamps shouldn't clash", func(t *testing.T) {
+		assert.Equal(t, n, len(setOfTimestamps))
+	})
+
+	re := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(.\d+)?Z$`)
+
+	t.Run("should return a valid ISO8601 date", func(t *testing.T) {
+		for timestamp := range setOfTimestamps {
+			t.Run(timestamp+" is a valid ISO8601 date", func(t *testing.T) {
+				assert.Regexp(t, re, timestamp)
+			})
+		}
 	})
 }

--- a/db/updateItem.go
+++ b/db/updateItem.go
@@ -21,7 +21,8 @@ func (d *dynamoDB) UpdateItem(listID string, itemID string, newName string, isCo
 		panic("Items table name not set")
 	}
 
-	fieldsToUpdate, updateExpression, expressionAttributeNames := getUpdateFields(newName, isCompleted)
+	timestamp := d.getTimestamp()
+	fieldsToUpdate, updateExpression, expressionAttributeNames := getUpdateFields(newName, isCompleted, timestamp)
 	input := &dynamodb.UpdateItemInput{
 		ExpressionAttributeValues: fieldsToUpdate,
 		Key:                       key,
@@ -54,7 +55,7 @@ func (d *dynamoDB) UpdateItem(listID string, itemID string, newName string, isCo
 	return item, err
 }
 
-func getUpdateFields(newName string, isCompleted *bool) (map[string]*dynamodb.AttributeValue, *string, map[string]*string) {
+func getUpdateFields(newName string, isCompleted *bool, timestamp string) (map[string]*dynamodb.AttributeValue, *string, map[string]*string) {
 	fields := map[string]*dynamodb.AttributeValue{}
 	var expressionAttributeNames map[string]*string
 	var updateExpression *string
@@ -69,6 +70,10 @@ func getUpdateFields(newName string, isCompleted *bool) (map[string]*dynamodb.At
 		expressionAttributeNames = appendNames(expressionAttributeNames, "#n", "Name")
 		updateExpression = appendUpdateExpression(updateExpression, "#n = :n")
 	}
+
+	// Updated timestamp
+	fields[":t"] = &dynamodb.AttributeValue{S: &timestamp}
+	updateExpression = appendUpdateExpression(updateExpression, "Updated = :t")
 
 	return fields, updateExpression, expressionAttributeNames
 }


### PR DESCRIPTION
These timestamps will be used when items are changed to work out which version is the most recent.

```bash
curl -s localhost:3000/lists -X POST -d '{"Name": "Shared List"}' | jq
{
  "Id": "ebb295b9-7098-42cb-b941-e7294a511943",
  "Name": "Shared List",
  "Created": "2020-12-07T07:51:55.1865789Z",
  "Updated": "2020-12-07T07:51:55.1865789Z"
}
```